### PR TITLE
Correct description of Claude Certified Architects Prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ jupyter notebook
 | [CCA sample questions PDF](https://claudecertified.com/downloads/cca-sample-5q.pdf) | Third-party | Small third-party sample PDF |
 | [Panaversity CCA-F page](https://panaversity.org/certifications/exams/CCA-F) | Third-party | Domain and scenario overview |
 | [Claude Certified Architect Practice](https://www.claudecertifiedarchitect.dev/) | Third-party | Scenario questions and domain diagnostics |
-| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | Third-party | Course-based prep and full-length practice exam |
+| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | Third-party | 400+ practice questions by domain, free diagnostic, timed 60-question mock |
 | [ClaudeCertified practice questions](https://claudecertified.com/cca-practice-questions) | Third-party | Practice-question PDFs |
 | [Claude Architect Lab](https://www.anthropiccertifications.com/) | Third-party | Adaptive practice, mock exam, and tutor |
 | [Udemy practice exams](https://www.udemy.com/course/claude-certified-architect-foundations-practice-tests-2026/) | Third-party | Paid practice exams |

--- a/README.zh.md
+++ b/README.zh.md
@@ -497,7 +497,7 @@ jupyter notebook
 | 资源 | 类型 | 推荐用途 |
 | --- | --- | --- |
 | [Claude Certified Architect Practice](https://www.claudecertifiedarchitect.dev/) | 题库平台 | 大量场景题、模拟考试和分域诊断 |
-| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | 课程/题库 | 课程化备考和 full-length practice exam |
+| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | 题库平台 | 400+ 道练习题，覆盖五个 domain，含免费诊断和 60 题限时模拟考 |
 | [ClaudeCertified practice questions](https://claudecertified.com/cca-practice-questions) | PDF 题库 | 小规模题库和样题 PDF |
 | [Claude Architect Lab](https://www.anthropiccertifications.com/) | 题库平台 | adaptive practice、mock exam、AI tutor |
 | [Udemy practice exams](https://www.udemy.com/course/claude-certified-architect-foundations-practice-tests-2026/) | 付费课程 | 额外模拟题训练 |

--- a/en/README.md
+++ b/en/README.md
@@ -330,7 +330,7 @@ jupyter notebook
 | [CCA sample questions PDF](https://claudecertified.com/downloads/cca-sample-5q.pdf) | Third-party | Small third-party sample PDF |
 | [Panaversity CCA-F page](https://panaversity.org/certifications/exams/CCA-F) | Third-party | Domain and scenario overview |
 | [Claude Certified Architect Practice](https://www.claudecertifiedarchitect.dev/) | Third-party | Scenario questions and domain diagnostics |
-| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | Third-party | Course-based prep and full-length practice exam |
+| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | Third-party | 400+ practice questions by domain, free diagnostic, timed 60-question mock |
 | [ClaudeCertified practice questions](https://claudecertified.com/cca-practice-questions) | Third-party | Practice-question PDFs |
 | [Claude Architect Lab](https://www.anthropiccertifications.com/) | Third-party | Adaptive practice, mock exam, and tutor |
 | [Udemy practice exams](https://www.udemy.com/course/claude-certified-architect-foundations-practice-tests-2026/) | Third-party | Paid practice exams |

--- a/zh/README.md
+++ b/zh/README.md
@@ -497,7 +497,7 @@ jupyter notebook
 | 资源 | 类型 | 推荐用途 |
 | --- | --- | --- |
 | [Claude Certified Architect Practice](https://www.claudecertifiedarchitect.dev/) | 题库平台 | 大量场景题、模拟考试和分域诊断 |
-| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | 课程/题库 | 课程化备考和 full-length practice exam |
+| [Claude Certified Architects Prep](https://www.claudecertifiedarchitects.com/) | 题库平台 | 400+ 道练习题，覆盖五个 domain，含免费诊断和 60 题限时模拟考 |
 | [ClaudeCertified practice questions](https://claudecertified.com/cca-practice-questions) | PDF 题库 | 小规模题库和样题 PDF |
 | [Claude Architect Lab](https://www.anthropiccertifications.com/) | 题库平台 | adaptive practice、mock exam、AI tutor |
 | [Udemy practice exams](https://www.udemy.com/course/claude-certified-architect-foundations-practice-tests-2026/) | 付费课程 | 额外模拟题训练 |


### PR DESCRIPTION
Small accuracy fix across all four README variants (README.md, README.zh.md, en/README.md, zh/README.md). The entry describes the site as "course-based prep" — it isn't a course, it's a practice question bank: 400+ questions across the five domains, a free 10-question diagnostic, and a timed 60-question mock in the official format.

Both zh tables also list the type as 课程/题库; changed to 题库平台 to match the two comparable entries in the same table.

Disclosure: I publish the site. Not adding any links — this only corrects the description of an entry that's already listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Claude Certified Architects Prep listing across English and Chinese resources.
  * Clarified that it offers 400+ practice questions across five domains, a free diagnostic, and a timed 60-question mock exam.
  * Reclassified the resource as a practice-question platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->